### PR TITLE
added private mode detection to browser-detection.js

### DIFF
--- a/browser-detection/browser-detection.js
+++ b/browser-detection/browser-detection.js
@@ -31,44 +31,43 @@ export default class BrowserDetection {
      * @returns {Promise}
      */
     static isPrivateMode() {
-      return new Promise((resolve) => {
-        const on = () => { resolve(true) }; // is in private mode
-        const off = () => { resolve(false) }; // not private mode
-        const isSafari = () => {
-          return (
-              /Constructor/.test(window.HTMLElement) ||
-              (function (root) {
-                return (!root || root.pushNotification).toString() === '[object SafariRemoteNotification]';
-               }
-              )(window.safari)
-            );
-        };
-        // Chrome & Opera
-        if (window.webkitRequestFileSystem) {
-          return void window.webkitRequestFileSystem(0, 0, off, on);
-        }
-        // Firefox
-        if ('MozAppearance' in document.documentElement.style) {
-          const db = indexedDB.open(null);
-          db.onerror = on;
-          db.onsuccess = off;
-          return void 0;
-        }
-        // Safari
-        if ( isSafari() ) {
-          try {
-            window.openDatabase(null, null, null, null);
-          } catch (_) {
-            return on();
-          }
-        }
-        // IE10+ & Edge
-        if (!window.indexedDB && (window.PointerEvent || window.MSPointerEvent)) {
-          return on();
-        }
-        // others
-        return off();
-      });
+        return new Promise((resolve) => {
+            const on = () => { resolve(true) }; // is in private mode
+            const off = () => { resolve(false) }; // not private mode
+            const isSafari = () => {
+                return (
+                    /Constructor/.test(window.HTMLElement) ||
+                    (function (root) {
+                            return (!root || root.pushNotification).toString() === '[object SafariRemoteNotification]';
+                        }
+                    )(window.safari)
+                );
+            };
+            // Chrome & Opera
+            if (window.webkitRequestFileSystem) {
+                return void window.webkitRequestFileSystem(0, 0, off, on);
+            }
+            // Firefox
+            if ('MozAppearance' in document.documentElement.style) {
+                const db = indexedDB.open(null);
+                db.onerror = on;
+                db.onsuccess = off;
+                return void 0;
+            }
+            // Safari
+            if ( isSafari() ) {
+                try {
+                    window.openDatabase(null, null, null, null);
+                } catch (_) {
+                    return on();
+                }
+            }
+            // IE10+ & Edge
+            if (!window.indexedDB && (window.PointerEvent || window.MSPointerEvent)) {
+                return on();
+            }
+            // others
+            return off();
+        });
     }
-
 }

--- a/browser-detection/browser-detection.js
+++ b/browser-detection/browser-detection.js
@@ -24,4 +24,51 @@ export default class BrowserDetection {
         const version = this.iOSversion();
         return version[0] < 11 || (version[0] === 11 && version[1] === 2) // Only 11.2 has the WASM bug
     }
+
+    /**
+     * Detect if the browser is running in Private Browsing mode
+     *
+     * @returns {Promise}
+     */
+    static isPrivateMode() {
+      return new Promise((resolve) => {
+        const on = () => { resolve(true) }; // is in private mode
+        const off = () => { resolve(false) }; // not private mode
+        const isSafari = () => {
+          return (
+              /Constructor/.test(window.HTMLElement) ||
+              (function (root) {
+                return (!root || root.pushNotification).toString() === '[object SafariRemoteNotification]';
+               }
+              )(window.safari)
+            );
+        };
+        // Chrome & Opera
+        if (window.webkitRequestFileSystem) {
+          return void window.webkitRequestFileSystem(0, 0, off, on);
+        }
+        // Firefox
+        if ('MozAppearance' in document.documentElement.style) {
+          const db = indexedDB.open(null);
+          db.onerror = on;
+          db.onsuccess = off;
+          return void 0;
+        }
+        // Safari
+        if ( isSafari() ) {
+          try {
+            window.openDatabase(null, null, null, null);
+          } catch (_) {
+            return on();
+          }
+        }
+        // IE10+ & Edge
+        if (!window.indexedDB && (window.PointerEvent || window.MSPointerEvent)) {
+          return on();
+        }
+        // others
+        return off();
+      });
+    }
+
 }


### PR DESCRIPTION
Commit Message says it all.

Tested in Chrome, Firefox, Safari, Edge and IE11. (Backwards compatible version is already part of a pull request to the browser-warning.js in Elements.)